### PR TITLE
Use question mark when selecting test specifications.

### DIFF
--- a/lib/cocoapods/generate/podfile_generator.rb
+++ b/lib/cocoapods/generate/podfile_generator.rb
@@ -51,7 +51,7 @@ module Pod
 
           self.defined_in_file = dir.join('Podfile.yaml')
 
-          test_specs = spec.recursive_subspecs.select(&:test_specification)
+          test_specs = spec.recursive_subspecs.select(&:test_specification?)
 
           # Stick all of the transitive dependencies in an abstract target.
           # This allows us to force CocoaPods to use the versions / sources / external sources


### PR DESCRIPTION
Just changes the method being used to be more conventional. This is put ahead of a breaking change that i'll be adding to Core.