### PR TITLE
Prevent `:podspec_paths` from being swallowed when specified in .gen_config.yml

### DIFF
--- a/lib/cocoapods/command/gen.rb
+++ b/lib/cocoapods/command/gen.rb
@@ -86,10 +86,12 @@ module Pod
           path = dir + '.gen_config.yml'
           next unless path.file?
           Pod::Generate::Configuration.from_file(path)
-        end
+        end.compact
+
+        options.delete(:podspec_paths) if options[:podspec_paths].empty? && config_hashes.any? { |h| h.include?(:podspec_paths) }
 
         env = Generate::Configuration.from_env(ENV)
-        config_hashes.insert(-2, env)
+        config_hashes = [env] + config_hashes
         config_hashes << options
 
         configuration = config_hashes.compact.each_with_object({}) { |e, h| h.merge!(e) }

--- a/spec/cocoapods/command/gen_spec.rb
+++ b/spec/cocoapods/command/gen_spec.rb
@@ -283,6 +283,27 @@ RSpec.describe Pod::Command::Gen, :tmpdir do
             )
           end
         end
+
+        describe 'when specifying :podspec_paths in configuration files' do
+          let(:argv) { [] }
+          before do
+            Pathname('A.podspec').write('Pod::Spec.new')
+            Pathname('B.podspec').write('Pod::Spec.new')
+            local_config_path = Pathname.pwd.join('.gen_config.yml')
+            local_config = {
+              podspec_paths: ['A.podspec', 'B.podspec'],
+              sources: %w[C D]
+            }
+            local_config_path.write Pod::YAMLHelper.convert(local_config)
+          end
+
+          it do
+            should eq Pod::Generate::Configuration.new(
+              podspec_paths: [Pathname('A.podspec').expand_path, Pathname('B.podspec').expand_path], # local config
+              sources: %w[C D], # local config
+            )
+          end
+        end
       end
 
       it 'only loads the Podfile once' do

--- a/spec/cocoapods/command/gen_spec.rb
+++ b/spec/cocoapods/command/gen_spec.rb
@@ -304,6 +304,27 @@ RSpec.describe Pod::Command::Gen, :tmpdir do
             )
           end
         end
+
+        describe 'when specifying :podspec_paths in configuration files and CLI args' do
+          let(:argv) { %w[C.podspec D.podspec] }
+          before do
+            Pathname('C.podspec').write('Pod::Spec.new')
+            Pathname('D.podspec').write('Pod::Spec.new')
+            local_config_path = Pathname.pwd.join('.gen_config.yml')
+            local_config = {
+              podspec_paths: ['SomePodspec.podspec', 'OtherPodspec.podspec'],
+              sources: %w[A B]
+            }
+            local_config_path.write Pod::YAMLHelper.convert(local_config)
+          end
+
+          it 'overrides config options with CLI args' do
+            should eq Pod::Generate::Configuration.new(
+              podspec_paths: [Pathname('C.podspec').expand_path, Pathname('D.podspec').expand_path], # local config
+              sources: %w[A B], # local config
+            )
+          end
+        end
       end
 
       it 'only loads the Podfile once' do

--- a/spec/integration/app_host_source_dir/after/execution_output.txt
+++ b/spec/integration/app_host_source_dir/after/execution_output.txt
@@ -12,7 +12,7 @@ CLAIDE_DISABLE_AUTO_WRAP=TRUE COCOAPODS_SKIP_CACHE=TRUE COCOAPODS_VALIDATOR_SKIP
   auto_open: false,
   clean: true,
   app_host_source_dir: ./spec/integration/tmp/app_host_source_dir/transformed/AppHost,
-  podspec_paths: [],
+  podspec_paths: [#<Pathname:./spec/integration/tmp/app_host_source_dir/transformed/Foo.podspec>],
   podspecs: [#<Pod::Specification name="Foo">],
   sources: ["https://github.com/Private/SpecsForks.git", "https://github.com/CocoaPods/Specs.git"],
   local_sources: [],

--- a/spec/integration/swift-objc-bridging-header/after/execution_output.txt
+++ b/spec/integration/swift-objc-bridging-header/after/execution_output.txt
@@ -12,7 +12,7 @@ CLAIDE_DISABLE_AUTO_WRAP=TRUE COCOAPODS_SKIP_CACHE=TRUE COCOAPODS_VALIDATOR_SKIP
   auto_open: false,
   clean: true,
   app_host_source_dir: ./spec/integration/tmp/swift-objc-bridging-header/transformed/AppHost,
-  podspec_paths: [],
+  podspec_paths: [#<Pathname:./spec/integration/tmp/swift-objc-bridging-header/transformed/Foo.podspec>],
   podspecs: [#<Pod::Specification name="Foo">],
   sources: ["https://github.com/Private/SpecsForks.git", "https://github.com/CocoaPods/Specs.git"],
   local_sources: [],


### PR DESCRIPTION
Closes #45