### PR TITLE
Fix Info.plist generation for macOS and tvOS on Xcode 14, and launchable iOS project

### DIFF
--- a/lib/cocoapods/generate/installer.rb
+++ b/lib/cocoapods/generate/installer.rb
@@ -238,7 +238,9 @@ module Pod
           when :ios
             make_ios_app_launchable(app_project, native_app_target)
           when :osx
-            make_macos_app_launchable(app_project, native_app_target)
+            generate_infoplist_file(app_project, native_app_target)
+          when :tvos
+            generate_infoplist_file(app_project, native_app_target)
           end
 
           swift_version = pod_targets.map { |pt| Pod::Version.new(pt.swift_version) }.max.to_s
@@ -393,10 +395,10 @@ module Pod
         native_app_target.resources_build_phase.add_file_reference(launch_storyboard_file_ref)
       end
 
-      def make_macos_app_launchable(app_project, native_app_target)
-        # Starting in Xcode 14, there is an error when you build the macOS app
-        # that is generated from cocoapods-generate. This implements the
-        # suggested change.
+      def generate_infoplist_file(app_project, native_app_target)
+        # Starting in Xcode 14, there is an error when you build the macOS or
+        # tvOS app that is generated from cocoapods-generate. This implements
+        # the suggested change.
         native_app_target.build_configurations.each do |bc|
           bc.build_settings['GENERATE_INFOPLIST_FILE'] = "YES"
         end

--- a/lib/cocoapods/generate/installer.rb
+++ b/lib/cocoapods/generate/installer.rb
@@ -234,9 +234,11 @@ module Pod
             bc.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'org.cocoapods-generate.${PRODUCT_NAME:rfc1034identifier}'
           end
 
-          case native_app_target.platform_name
+          case native_app_target.platform_name.to_sym
           when :ios
             make_ios_app_launchable(app_project, native_app_target)
+          when :osx
+            make_macos_app_launchable(app_project, native_app_target)
           end
 
           swift_version = pod_targets.map { |pt| Pod::Version.new(pt.swift_version) }.max.to_s
@@ -389,6 +391,15 @@ module Pod
         group.files.find { |f| f.display_name == 'Info.plist' } || group.new_file(info_plist_path)
         launch_storyboard_file_ref = group.files.find { |f| f.display_name == 'LaunchScreen.storyboard' } || group.new_file(launch_storyboard)
         native_app_target.resources_build_phase.add_file_reference(launch_storyboard_file_ref)
+      end
+
+      def make_macos_app_launchable(app_project, native_app_target)
+        # Starting in Xcode 14, there is an error when you build the macOS app
+        # that is generated from cocoapods-generate. This implements the
+        # suggested change.
+        native_app_target.build_configurations.each do |bc|
+          bc.build_settings['GENERATE_INFOPLIST_FILE'] = "YES"
+        end
       end
 
       def group_for_platform_name(project, platform_name, should_create = true)


### PR DESCRIPTION
On Xcode 14, when you generate a project with macOS or tvOS included, and try to build, you are met with an error:

![Screen Shot 2022-10-24 at 10 41 46 AM](https://user-images.githubusercontent.com/555046/197553882-3583d9d2-5a92-4168-9c1b-757554006cd7.png)

This PR does 2 things
 - Implements the suggested fix by updating that build setting in the generated project.
 - In addition, there is a bug where the `when :ios` case wasn't being hit, because `native_app_target.platform_name` is not a symbol. This PR fixes that bug.